### PR TITLE
feat: Migrate cron job from vexhub-crawler to vexhub repository

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run vexhub-crawler
         run: |
-          vexhub-crawler --vexhub-dir ./vexhub
+          vexhub-crawler --config ./vexhub-crawler/crawler.yaml --vexhub-dir ./vexhub
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   update:
     name: Update VEX Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       VEXHUB_CRAWLER_COMMIT: "691c2aaad9e15493af3416edb96b787e954ef1f7"
     steps:

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,0 +1,60 @@
+name: Update VEX Hub
+on:
+  schedule:
+    - cron: "0 0 * * *" # Every day
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  update:
+    name: Update VEX Hub
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VEXHUB_CRAWLER_COMMIT: "691c2aaad9e15493af3416edb96b787e954ef1f7"
+    steps:
+      - name: Check out vexhub repository
+        uses: actions/checkout@v4
+        with:
+          path: vexhub
+
+      - name: Check out vexhub-crawler
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/vexhub-crawler
+          ref: ${{ env.VEXHUB_CRAWLER_COMMIT }}
+          path: vexhub-crawler
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: vexhub-crawler/go.mod
+
+      - name: Set up git user
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+
+      - name: Build vexhub-crawler
+        run: |
+          cd vexhub-crawler
+          go build -o ../vexhub-crawler .
+          cd ..
+
+      - name: Run vexhub-crawler
+        run: |
+          ./vexhub-crawler --vexhub-dir ./vexhub
+
+      - name: Commit and push changes
+        run: |
+          cd vexhub
+          if [[ -n $(git status --porcelain) ]]; then
+            git add .
+            git commit -m "Update VEX documents"
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -41,12 +41,12 @@ jobs:
       - name: Build vexhub-crawler
         run: |
           cd vexhub-crawler
-          go build -o ../vexhub-crawler .
+          go install .
           cd ..
 
       - name: Run vexhub-crawler
         run: |
-          ./vexhub-crawler --vexhub-dir ./vexhub
+          vexhub-crawler --vexhub-dir ./vexhub
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -13,7 +13,6 @@ jobs:
     name: Update VEX Hub
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       VEXHUB_CRAWLER_COMMIT: "691c2aaad9e15493af3416edb96b787e954ef1f7"
     steps:
       - name: Check out vexhub repository


### PR DESCRIPTION
## Summary
Migrate the cron job workflow from vexhub-crawler repository to vexhub repository to prevent GitHub Actions from being disabled due to inactivity.

## Background
As discussed in https://github.com/aquasecurity/vexhub-crawler/discussions/40, the GitHub Actions workflow in vexhub-crawler was disabled due to repository inactivity. Since the vexhub repository has regular commits (timestamp updates in index.json), moving the workflow here should prevent future disabling due to inactivity.

## Changes
- Add `.github/workflows/cron.yaml` that runs daily to update VEX documents
- Build vexhub-crawler from source (pinned to commit [691c2aaad9e15493af3416edb96b787e954ef1f7](https://github.com/aquasecurity/vexhub-crawler/commit/691c2aaad9e15493af3416edb96b787e954ef1f7), current head)
- Use `secrets.GITHUB_TOKEN` instead of `ORG_REPO_TOKEN` for better security
- Apply GitHub Actions security best practices with explicit permissions

## Test Results
Successfully tested in fork: https://github.com/knqyf263/vexhub/actions/runs/15533094872

## Security Improvements
- Use minimal permissions (`contents: write`, `actions: read`)
- Replace `ORG_REPO_TOKEN` with built-in `GITHUB_TOKEN`
- Clone repositories to separate directories to prevent accidental commits