### PR TITLE
Update cron.yaml to use current tip of 'main' branch for crawler

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Update VEX Hub
     runs-on: ubuntu-24.04
     env:
-      VEXHUB_CRAWLER_COMMIT: "691c2aaad9e15493af3416edb96b787e954ef1f7"
+      VEXHUB_CRAWLER_COMMIT: "12dbf9a0ad3531a107bf06f618e2308f34b0a5e8"
     steps:
       - name: Check out vexhub repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This updates the pinned commit to the current tip of the main branch.